### PR TITLE
Improve encapsulation by not using parent classes' instance variables directly

### DIFF
--- a/examples/permissions/config.ru
+++ b/examples/permissions/config.ru
@@ -5,7 +5,7 @@ require 'api_valve'
 
 class MyPermissions < ApiValve::Forwarder::PermissionHandler
   def check_permissions!
-    raise ApiValve::Error::Forbidden unless @request.env['HTTP_AUTHORIZATION'] == 'Bearer my-api-token'
+    raise ApiValve::Error::Forbidden unless env['HTTP_AUTHORIZATION'] == 'Bearer my-api-token'
   end
 end
 

--- a/lib/api_valve/forwarder.rb
+++ b/lib/api_valve/forwarder.rb
@@ -1,6 +1,6 @@
 module ApiValve
   # This class is responsible for forwarding the HTTP request to the
-  # designated endpoint. It is instanciated once per Proxy with relevant
+  # designated endpoint. It is instantiated once per Proxy with relevant
   # options, and called from the router.
 
   class Forwarder
@@ -21,7 +21,7 @@ module ApiValve
     end
 
     # Takes the original rack request with optional options and returns a rack response
-    # Instanciates the Request and Response classes and wraps them arround the original
+    # Instantiates the Request and Response classes and wraps them around the original
     # request and response.
     def call(original_request, local_options = {})
       request = build_request(original_request, request_options.deep_merge(local_options))

--- a/lib/api_valve/forwarder/permission_handler.rb
+++ b/lib/api_valve/forwarder/permission_handler.rb
@@ -10,7 +10,7 @@ module ApiValve
       private
 
       def permission_handler
-        permission_handler_klass.instance(@original_request, permission_handler_options)
+        permission_handler_klass.instance(original_request, permission_handler_options)
       end
 
       def permission_handler_klass
@@ -18,9 +18,13 @@ module ApiValve
       end
 
       def permission_handler_options
-        @options[:permission_handler] || {}
+        options[:permission_handler] || {}
       end
     end
+
+    attr_reader :request, :options
+
+    delegate :env, to: :request
 
     # Returns an instance of the PermissionHandler, cached in the request env
     # This allows re-use of the PermissionHandler by both Request and Response instances

--- a/lib/api_valve/forwarder/response.rb
+++ b/lib/api_valve/forwarder/response.rb
@@ -9,9 +9,10 @@ module ApiValve
   # to the original caller
 
   class Forwarder::Response
+    # FIXME: does response use permissions or check against them (here or in gem clients)?
     include Forwarder::PermissionHandler::RequestIntegration
 
-    attr_reader :original_request, :original_response
+    attr_reader :original_request, :original_response, :options
 
     WHITELISTED_HEADERS = %w(
       Cache-Control

--- a/lib/api_valve/forwarder/response.rb
+++ b/lib/api_valve/forwarder/response.rb
@@ -9,7 +9,6 @@ module ApiValve
   # to the original caller
 
   class Forwarder::Response
-    # FIXME: does response use permissions or check against them (here or in gem clients)?
     include Forwarder::PermissionHandler::RequestIntegration
 
     attr_reader :original_request, :original_response, :options


### PR DESCRIPTION
Hello and thank you for creating this gem!

I've noticed that instance variables from parent classes are referenced in child classes as well as in examples. While this is not a problem if contained inside the gem, it might make future changes to the codebase harder because clients you've no control of are suggested to inherit from gem's classes (namely, from `Forwarder::PermissionHandler`).

I hope you don't mind polishing this a bit 🙂 