### PR TITLE
Instrumenting requests using Active support

### DIFF
--- a/lib/api_valve/forwarder.rb
+++ b/lib/api_valve/forwarder.rb
@@ -69,7 +69,7 @@ module ApiValve
     end
 
     def log_request(request)
-      ApiValve.logger.info do
+      ApiValve.logger.debug do
         format(
           '-> %<method>s %<endpoint>s%<path>s',
           method:   request.method.upcase,
@@ -80,7 +80,7 @@ module ApiValve
     end
 
     def log_response(response, elapsed_time)
-      ApiValve.logger.info do
+      ApiValve.logger.debug do
         format(
           '<- %<status>s in %<ms>dms',
           status: response.status,
@@ -94,6 +94,7 @@ module ApiValve
         url: endpoint,
         ssl: {verify: false}
       ) do |config|
+        config.request :instrumentation
         config.adapter Faraday.default_adapter
       end
     end

--- a/lib/api_valve/middleware/permission_check.rb
+++ b/lib/api_valve/middleware/permission_check.rb
@@ -11,7 +11,7 @@ class ApiValve::Middleware
         @app.call(env)
       else
         message = handler(env).message
-        ApiValve.logger.info { message }
+        ApiValve.logger.debug { message }
         render_error ApiValve::Error::Forbidden.new message
       end
     end


### PR DESCRIPTION
- Allowing user to subscribe to the default event name and instrument the requests for logging purposes
- Set default log level to debug