### PR TITLE
Fix location rewrites for remote locations

### DIFF
--- a/lib/api_valve/forwarder.rb
+++ b/lib/api_valve/forwarder.rb
@@ -4,8 +4,9 @@ module ApiValve
   # options, and called from the router.
 
   class Forwarder
-    autoload :Request,  'api_valve/forwarder/request'
-    autoload :Response, 'api_valve/forwarder/response'
+    autoload :LocationConverter,  'api_valve/forwarder/location_converter'
+    autoload :Request,            'api_valve/forwarder/request'
+    autoload :Response,           'api_valve/forwarder/response'
 
     include Benchmarking
 

--- a/lib/api_valve/forwarder/location_converter.rb
+++ b/lib/api_valve/forwarder/location_converter.rb
@@ -1,0 +1,38 @@
+module ApiValve
+  class Forwarder::LocationConverter
+    def initialize(location, options)
+      @location = location
+      @options = options
+    end
+
+    def call
+      if other_host? || same_prefix?
+        @location.to_s
+      else
+        convert_location
+      end
+    end
+
+    private
+
+    def local_prefix
+      @options[:local_prefix].presence
+    end
+
+    def other_host?
+      @location.host && @options[:response_uri].host != @location.host
+    end
+
+    def same_prefix?
+      local_prefix == target_prefix
+    end
+
+    def target_prefix
+      @options[:target_prefix].presence
+    end
+
+    def convert_location
+      @location.to_s.gsub(/^#{@options[:target_prefix]}/, @options[:local_prefix])
+    end
+  end
+end

--- a/lib/api_valve/forwarder/response.rb
+++ b/lib/api_valve/forwarder/response.rb
@@ -56,9 +56,15 @@ module ApiValve
     end
 
     def adjust_location(location)
-      return location if @options[:target_prefix] == @options[:local_prefix]
+      return unless location
 
-      location&.gsub(/^#{@options[:target_prefix]}/, @options[:local_prefix])
+      Forwarder::LocationConverter.new(
+        URI(location),
+        @options.slice(:local_prefix, :target_prefix).merge(
+          request_uri:  URI(@original_request.url),
+          response_uri: @original_response.env.url # already a URI
+        )
+      ).call
     end
 
     def body

--- a/spec/api_valve/forwarder/response_spec.rb
+++ b/spec/api_valve/forwarder/response_spec.rb
@@ -8,57 +8,79 @@ RSpec.describe ApiValve::Forwarder::Response do
       'REQUEST_METHOD'         => 'GET',
       'QUERY_STRING'           => 'foo=bar&array[]=1&array[]=2',
       'HTTP_X_FORWARDED_FOR'   => '212.122.121.211',
-      'HTTP_X_FORWARDED_HOST'  => 'api.example.com',
+      'HTTP_X_FORWARDED_HOST'  => host,
       'HTTP_X_FORWARDED_PORT'  => '443',
       'HTTP_X_FORWARDED_PROTO' => 'https',
       'HTTP_USER_AGENT'        => 'Faraday',
       'HTTP_OTHER_HEADER'      => 'Ignored'
     }
   end
-  let(:original_response) { instance_double(Faraday::Response, headers: response_headers, status: 301, body: nil) }
+  let(:faraday_env) do
+    {
+      response_headers: response_headers,
+      status:           301,
+      response_body:    nil,
+      url:              URI.join("https://#{host}", *[remote_prefix.presence, remote_path].compact)
+    }
+  end
+  let(:host) { 'api.example.com' }
+  let(:local_prefix) { '/proxy-prefix' }
+  let(:location) { nil }
+  let(:options) do
+    {
+      target_prefix: remote_prefix,
+      local_prefix:  local_prefix
+    }
+  end
+  let(:original_response) { Faraday::Response.new(faraday_env) }
+  let(:remote_prefix) { '/remote-prefix' }
+  let(:remote_path) { 'remote-path' }
   let(:response_headers) do
-    {'Location' => '/remote-prefix/see/other/path'}
+    {'Location' => location.presence}.compact
   end
   let(:rack_response) { response.rack_response }
-  let(:headers) { rack_response.headers }
 
   describe 'Location header' do
-    subject { headers['Location'] }
+    subject { rack_response.location }
 
     context 'when both remote and local have a prefix' do
-      let(:options) do
-        {
-          target_prefix: '/remote-prefix',
-          local_prefix:  '/proxy-prefix'
-        }
-      end
+      let(:location) { '/remote-prefix/original-redirect' }
+      let(:local_prefix) { '/proxy-prefix' }
+      let(:remote_prefix) { '/remote-prefix' }
 
-      it { is_expected.to eq '/proxy-prefix/see/other/path' }
+      it { is_expected.to eq '/proxy-prefix/original-redirect' }
     end
 
     context 'when only remote has a prefix' do
-      let(:options) do
-        {
-          target_prefix: '/remote-prefix',
-          local_prefix:  ''
-        }
-      end
+      let(:location) { '/remote-prefix/original-redirect' }
+      let(:local_prefix) { '' }
+      let(:remote_prefix) { '/remote-prefix' }
 
-      it { is_expected.to eq '/see/other/path' }
+      it { is_expected.to eq '/original-redirect' }
     end
 
     context 'when only local has a prefix' do
-      let(:options) do
-        {
-          target_prefix: '',
-          local_prefix:  '/proxy-prefix'
-        }
-      end
-      let(:response_headers) do
-        {'Location' => '/see/other/path'}
-      end
+      let(:location) { '/original-redirect' }
+      let(:local_prefix) { '/local-prefix' }
+      let(:remote_prefix) { '' }
 
-      it { is_expected.to eq '/proxy-prefix/see/other/path' }
+      it { is_expected.to eq '/local-prefix/original-redirect' }
+    end
+
+    context 'when neither has a prefix' do
+      let(:location) { '/original-redirect' }
+      let(:local_prefix) { '' }
+      let(:remote_prefix) { '' }
+
+      it { is_expected.to eq location }
+    end
+
+    context 'when it points to a different host' do
+      let(:location) { 'https://otherhost.com/original-redirect' }
+      let(:local_prefix) { '/proxy-prefix' }
+      let(:remote_prefix) { '/remote-prefix' }
+
+      it { is_expected.to eq location }
     end
   end
 end


### PR DESCRIPTION
Fixes redirects to different hosts, eg when location header returned by the proxy target is a full hostname instead of relative path.